### PR TITLE
Made script smarter by collecting info on the user that's running it and replaced captive-browser with Firefox

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,4 +3,6 @@ wg-captive-browser
 
 wg-captive-browser helps you connect to captive portals (guest wifi splash pages) without needing to disable your wireguard interface. It uses linux network namespaces to create a temporary namespace that does not get routed through the wireguard interface.
 
-wg-captive-browser is intended to be used with wg-quick and firefox with a special profile. It assumes you are routing all your traffic through the wg interface by using `ip rules` (which is what wg-quick does on linux).
+wg-captive-browser is intended to be used with wg-quick and captive-browser[1]. It assumes you are routing all your traffic through the wg interface by using `ip rules` (which is what wg-quick does on linux).
+
+[1]: https://github.com/FiloSottile/captive-browser

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,4 @@ wg-captive-browser
 
 wg-captive-browser helps you connect to captive portals (guest wifi splash pages) without needing to disable your wireguard interface. It uses linux network namespaces to create a temporary namespace that does not get routed through the wireguard interface.
 
-wg-captive-browser is intended to be used with wg-quick and captive-browser[1]. It assumes you are routing all your traffic through the wg interface by using `ip rules` (which is what wg-quick does on linux).
-
-[1]: https://github.com/FiloSottile/captive-browser
+wg-captive-browser is intended to be used with wg-quick and firefox with a special profile. It assumes you are routing all your traffic through the wg interface by using `ip rules` (which is what wg-quick does on linux).

--- a/wg-captive-browser.sh
+++ b/wg-captive-browser.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Get info about the user calling the script and the current active connection
-# Set up a new network namespace and start Firefox to handle any captive portals
+# Set up a new network namespace and start captive-browser to handle any captive portals
 set -ex
 
 physicalif=$(nmcli con show --active | grep -E 'wifi|ethernet' | awk '{print $4}')
@@ -8,8 +8,7 @@ browser_user=$(logname)
 wgif=wg0
 hostip=10.129.0.129
 nsip=10.129.0.130
-browser_command_profile="firefox -CreateProfile captive-portal"
-browser_command="firefox -P captive-portal -private-window"
+browser_command='captive-browser'
 
 netns=novpn
 hostif=novpnhost0
@@ -36,7 +35,6 @@ main() {
   add_veth
   add_iptable_rules
 
-  sudo -u $browser_user -i $browser_command_profile
   ip netns exec $netns sudo -u $browser_user -i $browser_command
 
   cleanup;


### PR DESCRIPTION
I added some stuff to the script that will make it a bit more autodetecting, assuming you are running NetworkManager. Also as captive-browser is no longer maintained (last commit was a long time ago), I added logic to handle creating a new Firefox Profile and launching that instead.